### PR TITLE
Group answers by answer ID in answer store to make filtering more eff…

### DIFF
--- a/app/data_model/answer_store.py
+++ b/app/data_model/answer_store.py
@@ -1,5 +1,7 @@
+import itertools
 import re
 
+from collections import defaultdict
 from datetime import datetime
 from jinja2 import escape
 import simplejson as json
@@ -59,6 +61,7 @@ class AnswerStore:
 
     def __init__(self, existing_answers=None):
         self.answers = existing_answers or []
+        self.answer_map = self._build_map(self.answers)
 
     def __iter__(self):
         return iter(self.answers)
@@ -66,8 +69,23 @@ class AnswerStore:
     def __getitem__(self, key):
         return self.answers[key]
 
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+
+        if key == 'answers':
+            self.answer_map = self._build_map(self.answers)
+
     def __len__(self):
         return len(self.answers)
+
+    @staticmethod
+    def _build_map(answers):
+        answer_map = defaultdict(list)
+
+        for answer in answers:
+            answer_map[answer['answer_id']].append(answer)
+
+        return answer_map
 
     @staticmethod
     def _validate(answer):
@@ -88,6 +106,7 @@ class AnswerStore:
             raise ValueError('Answer instance already exists in store')
         else:
             self.answers.append(answer_to_add)
+            self.answer_map[answer_to_add['answer_id']].append(answer_to_add)
 
     def copy(self):
         """
@@ -188,7 +207,12 @@ class AnswerStore:
             'group_instance': group_instance,
         }
 
-        for answer in self.answers:
+        if answer_ids:
+            answers = itertools.chain.from_iterable(self.answer_map[answer_id] for answer_id in answer_ids)
+        else:
+            answers = self.answers
+
+        for answer in answers:
             matches = all(
                 answer[key] in value if isinstance(value, list) else answer[key] == value
                 for key, value in filter_vars.items()
@@ -198,6 +222,7 @@ class AnswerStore:
                 filtered.append(answer)
                 if limit and len(filtered) == self.EQ_MAX_NUM_REPEATS:
                     break
+
         return self.__class__(existing_answers=filtered)
 
     def clear(self):
@@ -205,6 +230,7 @@ class AnswerStore:
         Clears answers *in place*
         """
         self.answers.clear()
+        self.answer_map = defaultdict(list)
 
     def remove(self, answer_ids=None, group_instance=None, answer_instance=None):
         """
@@ -215,6 +241,7 @@ class AnswerStore:
         :param group_instance: The group instance to filter results to remove
         """
         for answer in self.filter(answer_ids, group_instance=group_instance, answer_instance=answer_instance):
+            self.answer_map[answer['answer_id']].remove(answer)
             self.answers.remove(answer)
 
     def get_hash(self):

--- a/tests/app/data_model/test_questionnaire_store.py
+++ b/tests/app/data_model/test_questionnaire_store.py
@@ -12,7 +12,7 @@ def get_basic_input():
             'test': True
         },
         'ANSWERS': [{
-            'answer-id': 'test',
+            'answer_id': 'test',
             'value': 'test',
         }],
         'COMPLETED_BLOCKS': [

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -733,6 +733,7 @@ class TestNavigation(AppContextTestCase):
 
         answer_store.update(change_answer)
 
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
         user_navigation = navigation.build_navigation('property-details', 0)
 
         link_names = [d['link_name'] for d in user_navigation]


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a dict mapping of answer ID to a list of answers to the `AnswerStore` object. This makes calls to `AnswerStore.filter()` more efficient, especially with a large number of answers.

This reduced the CPU time by around 10ms for both GETs and POSTs during profiling. At this point the answer store was relatively small and a greater improvement would be expected for requests later in a large survey or for ones with a large number of repeating groups. 

### How to review 
Check code makes sense and there is no potential for the new `answer_map` object to get out of sync with the main list of answers.

Manually test application.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
