### PR TITLE
Cache template paths

### DIFF
--- a/app/flask_theme_cache.py
+++ b/app/flask_theme_cache.py
@@ -1,0 +1,19 @@
+import jinja2
+import flask_themes2
+
+
+def get_global_theme_template(cache):
+    @cache.memoize()
+    def _get_templatepath(theme, templatename, fallback):
+        templatepath = '_themes/{}/{}'.format(theme, templatename)
+        if (not fallback) or flask_themes2.template_exists(templatepath):
+            return templatepath
+        else:
+            return templatename
+
+    @jinja2.contextfunction
+    def global_theme_template(ctx, templatename, fallback=True):
+        theme = flask_themes2.active_theme(ctx)
+        return _get_templatepath(theme, templatename, fallback)
+
+    return global_theme_template

--- a/app/setup.py
+++ b/app/setup.py
@@ -19,6 +19,7 @@ from flask_wtf.csrf import CSRFProtect
 from sdc.crypto.key_store import KeyStore, validate_required_keys
 from structlog import get_logger
 
+from app import flask_theme_cache
 from app import settings
 from app.authentication.authenticator import login_manager
 from app.authentication.cookie_session import SHA256SecureCookieSessionInterface
@@ -140,6 +141,8 @@ def create_app(setting_overrides=None):  # noqa: C901  pylint: disable=too-compl
     # Add theme manager
     application.config['THEME_PATHS'] = os.path.dirname(os.path.abspath(__file__))
     Themes(application, app_identifier='surveyrunner')
+
+    application.jinja_env.globals['theme'] = flask_theme_cache.get_global_theme_template(cache)
 
     @application.before_request
     def before_request():  # pylint: disable=unused-variable


### PR DESCRIPTION
### What is the context of this PR?
The https://github.com/sysr-q/flask-themes2 library looks for a template given the current theme before falling back to a default. For each file required to render a response it walks the template directories searching for a matching template file.

This change caches the path to each template. On testing it represented an average 37ms drop in CPU time for GET requests (about 33% at that point). 

Note: this has nothing to do with the actual template cache that gets used once flask themes has identified the correct template.

### How to review 
General app testing. Ensure that schemas using different themes are tested without restarting the app.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
